### PR TITLE
Rename acknowledgement to resolved

### DIFF
--- a/tellme/admin.py
+++ b/tellme/admin.py
@@ -54,7 +54,7 @@ class FeedbackAdmin(admin.ModelAdmin):
 
     def unresolve(self, request, queryset):
         queryset.update(ack=False)
-        messages.info(request, _("Feedback(s) has been unresolved."),
+        messages.info(request, _("Feedback(s) have been unresolved."),
                       fail_silently=True)
     unresolve.short_description = _("Unresolve selected feedbacks")
 

--- a/tellme/admin.py
+++ b/tellme/admin.py
@@ -44,19 +44,19 @@ class FeedbackAdmin(admin.ModelAdmin):
     ordering = ("-created",)
     date_hierarchy = 'created'
 
-    actions = ('acknowledge', 'unacknowledge')
+    actions = ('resolve', 'unresolve')
 
-    def acknowledge(self, request, queryset):
+    def resolve(self, request, queryset):
         queryset.update(ack=True)
-        messages.info(request, _("Feedback(s) has been acknowledged."),
+        messages.info(request, _("Feedback(s) have been resolved."),
                       fail_silently=True)
-    acknowledge.short_description = _("Acknowledge selected feedbacks")
+    resolve.short_description = _("Resolve selected feedbacks")
 
-    def unacknowledge(self, request, queryset):
+    def unresolve(self, request, queryset):
         queryset.update(ack=False)
-        messages.info(request, _("Feedback(s) has been unacknowledged."),
+        messages.info(request, _("Feedback(s) has been unresolved."),
                       fail_silently=True)
-    unacknowledge.short_description = _("Unacknowledge selected feedbacks")
+    unresolve.short_description = _("Unresolve selected feedbacks")
 
     def screenshot_thumb(self, feedback):
         if feedback.screenshot:

--- a/tellme/migrations/0004_auto.py
+++ b/tellme/migrations/0004_auto.py
@@ -21,6 +21,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='feedback',
             name='ack',
-            field=models.BooleanField(default=False, verbose_name='Acknowledgement'),
+            field=models.BooleanField(default=False, verbose_name='Resolved'),
         ),
     ]

--- a/tellme/models.py
+++ b/tellme/models.py
@@ -17,7 +17,7 @@ class Feedback(models.Model):
     email = models.EmailField(max_length=254, blank=True, null=True)
     created = models.DateTimeField(_('Creation date'), auto_now_add=True, db_index=True)
 
-    ack = models.BooleanField(_('Acknowledgement'), default=False)
+    ack = models.BooleanField(_('Resolved'), default=False)
 
     class Meta:
         verbose_name = _("feedback")

--- a/tellme/templates/tellme/js_inc.html
+++ b/tellme/templates/tellme/js_inc.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 {#Extend with an empty block or replace with your version of jquery#}
-{%  block jquery %}
+{% block jquery %}
     <script src="//code.jquery.com/jquery-1.12.2.min.js"></script>
 {% endblock %}
 

--- a/tellme/tests/test_admin.py
+++ b/tellme/tests/test_admin.py
@@ -8,7 +8,7 @@ from tellme.models import Feedback
 from tellme.tests import factories
 
 
-class AdminAcknowledgeActionTest(TestCase):
+class AdminResolveActionTest(TestCase):
     url = reverse('admin:tellme_feedback_changelist')
 
     def test_action(self):
@@ -16,7 +16,7 @@ class AdminAcknowledgeActionTest(TestCase):
         feedback = factories.FeedbackFactory(ack=False)
         self.client.force_login(user)
         data = {
-            'action': 'acknowledge',
+            'action': 'resolve',
             '_selected_action': [feedback.id],
         }
         response = self.client.post(self.url, data, follow=True)
@@ -25,7 +25,7 @@ class AdminAcknowledgeActionTest(TestCase):
         self.assertTrue(feedback.ack)
 
 
-class AdminUnacknowledgeActionTest(TestCase):
+class AdminUnresolveActionTest(TestCase):
     url = reverse('admin:tellme_feedback_changelist')
 
     def test_action(self):
@@ -33,7 +33,7 @@ class AdminUnacknowledgeActionTest(TestCase):
         feedback = factories.FeedbackFactory(ack=True)
         self.client.force_login(user)
         data = {
-            'action': 'unacknowledge',
+            'action': 'unresolve',
             '_selected_action': [feedback.id],
         }
         response = self.client.post(self.url, data, follow=True)


### PR DESCRIPTION
Resolves #3 

Admins can mark feedbacks as 'resolved', this is clearer than the former